### PR TITLE
Fix broad phase for cube vs. sphere

### DIFF
--- a/benchmarks/benchmark_broad_phase.py
+++ b/benchmarks/benchmark_broad_phase.py
@@ -1,0 +1,28 @@
+import timeit
+import numpy as np
+from functools import partial
+from distance3d import hydroelastic_contact
+
+random_state = np.random.RandomState(0)
+
+
+def random_broad_phase_collisions(random_state, use_aabb_trees):
+    p = random_state.randn(3)
+    rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0 * np.ones(3), 0.15, 2)
+    rigid_body2 = hydroelastic_contact.RigidBody.make_sphere(p, 0.15, 2)
+
+    rigid_body1.express_in(rigid_body2.body2origin_)
+    hydroelastic_contact.broad_phase_tetrahedra(rigid_body1, rigid_body2, use_aabb_trees)
+
+
+repeat = 10
+number = 10
+times = timeit.repeat(partial(
+    random_broad_phase_collisions, random_state=random_state, use_aabb_trees=True),
+    repeat=repeat, number=number)
+print(f"AABB Trees Mean: {np.mean(times):.5f}; Std. dev.: {np.std(times):.5f}")
+
+times = timeit.repeat(partial(
+    random_broad_phase_collisions, random_state=random_state, use_aabb_trees=False),
+    repeat=repeat, number=number)
+print(f"Brute Force Mean: {np.mean(times):.5f}; Std. dev.: {np.std(times):.5f}")

--- a/distance3d/hydroelastic_contact/_broad_phase.py
+++ b/distance3d/hydroelastic_contact/_broad_phase.py
@@ -4,7 +4,7 @@ import numba
 from ._mesh_processing import tetrahedral_mesh_aabbs
 
 
-def broad_phase_tetrahedra(rigid_body1, rigid_body2):
+def broad_phase_tetrahedra(rigid_body1, rigid_body2, use_aabb_trees: bool = False):
     """Broad phase collision detection of tetrahedra.
 
     Parameters
@@ -14,6 +14,10 @@ def broad_phase_tetrahedra(rigid_body1, rigid_body2):
 
     rigid_body2 : RigidBody
         Second rigid body.
+
+    use_aabb_trees : bool
+        Option to specify the usage of a AABB trees.
+        Currently slower than a standard brute search.
 
     Returns
     -------
@@ -32,15 +36,10 @@ def broad_phase_tetrahedra(rigid_body1, rigid_body2):
     aabbs1 = tetrahedral_mesh_aabbs(rigid_body1.tetrahedra_points)
     aabbs2 = tetrahedral_mesh_aabbs(rigid_body2.tetrahedra_points)
 
-    # TODO fix broad phase for cube vs. sphere
-    # Result: The AABBs of an axis aligned Cube contains always two equal AABBs for every side of the cube.
-    # when unique is turned on the AABBs library deletes one pair hence the wrong results.
-
     # TODO speed up broad phase with numba
     # TODO store result in RigidBody
 
-    test_AABBs_Tree = False
-    if not test_AABBs_Tree:
+    if not use_aabb_trees:
         return _all_aabbs_overlap(aabbs1, aabbs2)
     else:
         tree2 = aabbtree.AABBTree()
@@ -61,8 +60,7 @@ def broad_phase_tetrahedra(rigid_body1, rigid_body2):
             else:
                 assert i not in broad_tetrahedra1
 
-        return broad_tetrahedra1, broad_tetrahedra2, broad_pairs
-
+        return np.array(broad_tetrahedra1, dtype=int), np.array(broad_tetrahedra2, dtype=int), broad_pairs
 
 @numba.njit(cache=True)
 def _all_aabbs_overlap(aabbs1, aabbs2):

--- a/distance3d/hydroelastic_contact/_broad_phase.py
+++ b/distance3d/hydroelastic_contact/_broad_phase.py
@@ -33,17 +33,20 @@ def broad_phase_tetrahedra(rigid_body1, rigid_body2):
     aabbs2 = tetrahedral_mesh_aabbs(rigid_body2.tetrahedra_points)
 
     # TODO fix broad phase for cube vs. sphere
+    # Result: The AABBs of an axis aligned Cube contains always two equal AABBs for every side of the cube.
+    # when unique is turned on the AABBs library deletes one pair hence the wrong results.
+
     # TODO speed up broad phase with numba
     # TODO store result in RigidBody
 
-    """
+
     tree2 = aabbtree.AABBTree()
     for j, aabb in enumerate(aabbs2):
         tree2.add(aabbtree.AABB(aabb), j)
     broad_tetrahedra1 = []
     broad_tetrahedra2 = []
     for i, aabb in enumerate(aabbs1):
-        new_indices2 = tree2.overlap_values(aabbtree.AABB(aabb))
+        new_indices2 = tree2.overlap_values(aabbtree.AABB(aabb), method='DFS', closed=False, unique=False)
         broad_tetrahedra2.extend(new_indices2)
         broad_tetrahedra1.extend([i] * len(new_indices2))
 
@@ -54,10 +57,8 @@ def broad_phase_tetrahedra(rigid_body1, rigid_body2):
             assert i in broad_tetrahedra1
         else:
             assert i not in broad_tetrahedra1
-    """
 
-    return _all_aabbs_overlap(aabbs1, aabbs2)
-
+    return broad_tetrahedra1, broad_tetrahedra2, broad_pairs
 
 @numba.njit(cache=True)
 def _all_aabbs_overlap(aabbs1, aabbs2):

--- a/distance3d/hydroelastic_contact/_interface.py
+++ b/distance3d/hydroelastic_contact/_interface.py
@@ -74,7 +74,7 @@ def find_contact_surface(rigid_body1, rigid_body2):
     rigid_body1.express_in(rigid_body2.body2origin_)
 
     broad_tetrahedra1, broad_tetrahedra2, broad_pairs = broad_phase_tetrahedra(
-        rigid_body1, rigid_body2)
+        rigid_body1, rigid_body2, False)
 
     unique_indices1 = np.unique(broad_tetrahedra1)
     unique_indices2 = np.unique(broad_tetrahedra2)

--- a/distance3d/test/test_cube_unique_pairs_edge_case.py
+++ b/distance3d/test/test_cube_unique_pairs_edge_case.py
@@ -1,0 +1,26 @@
+import numpy as np
+import unittest
+from distance3d import hydroelastic_contact
+import pytransform3d.rotations as pr
+
+
+def test_cube_unique_pairs(use_aabb_trees):
+    rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
+    cube2origin = np.eye(4)
+    cube2origin[:3, :3] = pr.active_matrix_from_extrinsic_euler_zyx([0.1, 0.3, 0.5])
+    cube2origin[:3, 3] = 0.25 * np.ones(3)
+    rigid_body2 = hydroelastic_contact.RigidBody.make_cube(cube2origin, 0.15)
+
+    rigid_body1.express_in(rigid_body2.body2origin_)
+    broad_tetrahedra1, broad_tetrahedra2, broad_pairs = hydroelastic_contact.broad_phase_tetrahedra(
+        rigid_body1, rigid_body2, use_aabb_trees)
+
+    assert len(broad_pairs) == 162
+
+
+class Testing(unittest.TestCase):
+    def test_cube_uique_pairs_brute_force(self):
+        test_cube_unique_pairs(False)
+
+    def test_cube_uique_pairs_aabb_tree(self):
+        test_cube_unique_pairs(True)

--- a/examples/visualizations/vis_pressure_field.py
+++ b/examples/visualizations/vis_pressure_field.py
@@ -9,24 +9,11 @@ import numpy as np
 import pytransform3d.visualizer as pv
 from distance3d import visualization, hydroelastic_contact, benchmark
 
-
 highlight_isect_idx = None
-show_broad_phase = True
+show_broad_phase = False
 
-test_Bug = True
-if test_Bug:
-    import pytransform3d.rotations as pr
-
-    rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
-    cube2origin = np.eye(4)
-    cube2origin[:3, :3] = pr.active_matrix_from_extrinsic_euler_zyx([0.1, 0.3, 0.5])
-    cube2origin[:3, 3] = 0.25 * np.ones(3)
-    rigid_body2 = hydroelastic_contact.RigidBody.make_cube(cube2origin, 0.15)
-
-else:
-    rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
-    rigid_body2 = hydroelastic_contact.RigidBody.make_sphere(0.25 * np.ones(3), 0.15, 2)
-
+rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
+rigid_body2 = hydroelastic_contact.RigidBody.make_sphere(0.25 * np.ones(3), 0.15, 2)
 
 timer = benchmark.Timer()
 timer.start("contact_forces")
@@ -65,8 +52,8 @@ if highlight_isect_idx is not None:
     fig.scatter(details["intersecting_tetrahedra1"][highlight_isect_idx], s=0.001, c=(1, 0, 0))
     fig.scatter(details["intersecting_tetrahedra2"][highlight_isect_idx], s=0.001, c=(0, 0, 1))
     fig.scatter([details["contact_coms"][highlight_isect_idx]], s=0.002, c=(1, 0, 1))
-    #visualization.Tetrahedron(details["intersecting_tetrahedra1"][highlight_isect_idx]).add_artist(fig)
-    #visualization.Tetrahedron(details["intersecting_tetrahedra2"][highlight_isect_idx]).add_artist(fig)
+    # visualization.Tetrahedron(details["intersecting_tetrahedra1"][highlight_isect_idx]).add_artist(fig)
+    # visualization.Tetrahedron(details["intersecting_tetrahedra2"][highlight_isect_idx]).add_artist(fig)
 
 fig.plot_vector(details["contact_point"], 100 * wrench21[:3], (1, 0, 0))
 fig.plot_vector(details["contact_point"], 100 * wrench12[:3], (0, 1, 0))

--- a/examples/visualizations/vis_pressure_field.py
+++ b/examples/visualizations/vis_pressure_field.py
@@ -11,10 +11,22 @@ from distance3d import visualization, hydroelastic_contact, benchmark
 
 
 highlight_isect_idx = None
-show_broad_phase = False
+show_broad_phase = True
 
-rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
-rigid_body2 = hydroelastic_contact.RigidBody.make_sphere(0.25 * np.ones(3), 0.15, 2)
+test_Bug = True
+if test_Bug:
+    import pytransform3d.rotations as pr
+
+    rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
+    cube2origin = np.eye(4)
+    cube2origin[:3, :3] = pr.active_matrix_from_extrinsic_euler_zyx([0.1, 0.3, 0.5])
+    cube2origin[:3, 3] = 0.25 * np.ones(3)
+    rigid_body2 = hydroelastic_contact.RigidBody.make_cube(cube2origin, 0.15)
+
+else:
+    rigid_body1 = hydroelastic_contact.RigidBody.make_sphere(0.13 * np.ones(3), 0.15, 2)
+    rigid_body2 = hydroelastic_contact.RigidBody.make_sphere(0.25 * np.ones(3), 0.15, 2)
+
 
 timer = benchmark.Timer()
 timer.start("contact_forces")


### PR DESCRIPTION
The AABBs of an axis aligned Cube contains always two equal AABBs for every side of the cube.
When unique is turned on the AABBs library deletes one pair hence the wrong results.

Calculation times on my machine:
AABB Tree time: 0.14666247367858887
Brute-Force time: 0.9549121856689453