### PR TITLE
Relax sanity check in gjk_distance_jolt and make assertion optional

### DIFF
--- a/distance3d/gjk/_gjk_jolt.py
+++ b/distance3d/gjk/_gjk_jolt.py
@@ -136,7 +136,7 @@ def _intersection_loop(
 
 
 def gjk_distance_jolt(
-        collider1, collider2, tolerance=1e-10, max_distance_squared=100000.0):
+        collider1, collider2, tolerance=1e-10, max_distance_squared=100000.0, sanity_check=1e-8):
     """Gilbert-Johnson-Keerthi (GJK) algorithm for distance calculation.
 
     This implementation extends the intersection test by closest point
@@ -166,6 +166,10 @@ def gjk_distance_jolt(
         The maximum squared distance between colliders before the objects are
         considered infinitely far away and processing is terminated.
 
+    sanity_check : float, optional (default: 1e-8)
+        Comparing intermediate result ( which should be close to zero )
+        to this sanity check value.
+        If sanity_check is non-zero, an assert will be triggered on mismatch.
 
     Returns
     -------
@@ -210,7 +214,9 @@ def gjk_distance_jolt(
             # Get the closest points
             a, b = calculate_closest_points(Y, P, Q, n_points)
 
-            assert abs(np.dot(search_direction, search_direction) - v_len_sq) < 1e-12
+            check_value = abs(np.dot(search_direction, search_direction) - v_len_sq)
+            assert not sanity_check or (sanity_check and check_value < sanity_check), f"Sanity check failed: {check_value}"
+            
             dist = math.sqrt(v_len_sq)
             if dist < EPSILON:
                 a = b = 0.5 * (a + b)

--- a/distance3d/gjk/_gjk_jolt.py
+++ b/distance3d/gjk/_gjk_jolt.py
@@ -167,9 +167,7 @@ def gjk_distance_jolt(
         considered infinitely far away and processing is terminated.
 
     sanity_check : float, optional (default: 1e-8)
-        Comparing intermediate result ( which should be close to zero )
-        to this sanity check value.
-        If sanity_check is non-zero, an assert will be triggered on mismatch.
+        Use `sanity_check=float("inf")` to bypass sanity check.
 
     Returns
     -------
@@ -215,7 +213,7 @@ def gjk_distance_jolt(
             a, b = calculate_closest_points(Y, P, Q, n_points)
 
             check_value = abs(np.dot(search_direction, search_direction) - v_len_sq)
-            assert not sanity_check or (sanity_check and check_value < sanity_check), f"Sanity check failed: {check_value}"
+            assert check_value < sanity_check, f"Sanity check failed: {check_value}"
             
             dist = math.sqrt(v_len_sq)
             if dist < EPSILON:


### PR DESCRIPTION
Relax sanity check to `1e-8` based on values seen in many collision tests.
Make sanity check optional by adding a new function argument to `gjk_distance_jolt`.